### PR TITLE
Set high priority on exam ical events

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -41,6 +41,11 @@ impl Lecture {
         }
         return lecturers;
     }
+
+    pub fn is_exam(&self) -> bool {
+        let name_lower = self.name.to_lowercase();
+        name_lower.contains("klausur") || name_lower.contains("prüfung")
+    }
 }
 
 pub async fn get_courses(client: &reqwest::Client, base_url: &str) -> Result<Vec<String>, Box<dyn std::error::Error>> {

--- a/src/icalendar.rs
+++ b/src/icalendar.rs
@@ -39,6 +39,10 @@ async fn write_lecture<W: AsyncWrite + std::marker::Unpin>(writer: &mut W, lectu
         format!("Dozent:innen: {}", lecture.lecturers().join(" & "))
     }).await?;
 
+    if lecture.is_exam() {
+        write_short_line(writer, "PRIORITY:1").await?;
+    }
+
     for lecturer in lecture.lecturers() {
         write_line(writer, format!("ATTENDEE;CN=\"{}\":noreply@mosbach.dhbw.de", lecturer).as_str()).await?;
     }


### PR DESCRIPTION
Sets the priority to 1 (the highest) for all events that have "klausur" or "prüfung" in the name which is the same criteria https://stuv.app uses to determine exams.

Btw this project currently has no open source license, which I assume to be an oversight instead of being intended ;)